### PR TITLE
search keyword incorrect

### DIFF
--- a/doc_source/setup-toolkit.md
+++ b/doc_source/setup-toolkit.md
@@ -30,7 +30,7 @@ Before you can use certain features of the Toolkit for VS Code, you must have th
 1. In the **Activity Bar** on the side of the VS Code editor, choose the **Extensions** icon\. This opens the **Extensions** view, which allows you to access the VS Code Marketplace\.  
 ![\[The Extensions icon in the VS Code Activity Bar.\]](http://docs.aws.amazon.com/toolkit-for-vscode/latest/userguide/images/aws-toolkit-extensions.png)
 
-1. In the search box for **Extensions**, search for **AWS Toolkit for Visual Studio Code**\. Choose the entry to see its details in the right pane\.
+1. In the search box for **Extensions**, search for **AWS Toolkit**\. Choose the entry to see its details in the right pane\.
 
 1. In the right pane, choose **Install**\.
 


### PR DESCRIPTION
Context:

In the search box for Extensions, search for AWS Toolkit for Visual Studio Code. Choose the entry to see its details in the right pane.

The name of the extension is "AWS Toolkit".