### PR TITLE
Fix virtualenv bash instructions

### DIFF
--- a/doc_source/setup-toolchain.md
+++ b/doc_source/setup-toolchain.md
@@ -35,7 +35,7 @@ The AWS Toolkit for Visual Studio Code supports multiple languages that you can 
 You only need to configure `virtualenv` once per system\.
 
 1. Activate `virtualenv` by running one of the following:
-   + Bash shell: `./.venv/Scripts/activate`
+   + Bash shell: `source ./.venv/bin/activate`
    + PowerShell: `./.venv/Scripts/Activate.ps1`
 
 ## Using Your toolchain<a name="use-toolchain"></a>


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
The bash virtualenv script path is incorrect and does not have the executable permission enabled by default either.

You must call it with either `source` or `.` before the relative file path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
