### PR TITLE
Removing the out of date NC licensing statement in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ To contribute your own documentation fixes or updates, please use standard GitHu
 
 All content in this repository, unless otherwise stated, is Copyright © 2010-2019, Amazon Web Services, Inc. or its affiliates. All rights reserved.
 
-Except where otherwise noted, this work is licensed under a [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0/) (the "License"). Use the preceding link for a human-readable summary of the license terms. The full license text is available at: http://creativecommons.org/licenses/by-nc-sa/4.0/legalcode and in the LICENSE file accompanying this repository.
-
-
 ## License Summary
 
 The documentation is made available under the Creative Commons Attribution-ShareAlike 4.0 International License. See the LICENSE file.


### PR DESCRIPTION

*Description of changes:*

This project is licensed CC-BY-SA-4.0 with MIT-0 for sample code. The CC-BY-NC-SA-4.0 mention in the README is a relic needing removal.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
